### PR TITLE
bug fix in row_normalized_transition_probabilities

### DIFF
--- a/src/mpp.cpp
+++ b/src/mpp.cpp
@@ -162,7 +162,7 @@ namespace Clustering {
       std::size_t n_cols = count_matrix.size2();
       SparseMatrixF transition_matrix(n_rows, n_cols);
       for (std::size_t i: cluster_names) {
-        std::size_t row_sum = 0;
+        float row_sum = 0;
         for (std::size_t j=0; j < n_cols; ++j) {
           row_sum += count_matrix(i,j);
         }


### PR DESCRIPTION
Hi all,

I found a small but annoying bug in the row normalization for the transition matrix. For a count matrix from weighted_transition_counts, the entries are not necessarily integer-valued. Using a row_sum of integer type introduces rounding errors and wrong normalization, i.e., not equal to one. The easy fix was to change the row_sum type from size_t to float.

Hope it helps.

All the best,
Gregor