### PR TITLE
Add conda section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,14 @@ TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF TH
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-
 # Installation
+This package can be installed with conda via
+```
+conda install moldyn-clustering -c conda-forge
+```
+If conda is not available, it can be compiled as well.
+
+# Compilation
 ## Requirements
  required:
   -  **BOOST >= 1.49**


### PR DESCRIPTION
As the conda installation was recently added to fastpca, adding it here as well.

Quite surprised by the number of downloads for these packages actually - ~900 for fastpca and ~1.4k for clustering (see https://anaconda.org/conda-forge/fastpca/files and https://anaconda.org/conda-forge/moldyn-clustering/files).